### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I tried to implement as many features I could (like `mask`, `transform` and `sym
 Please use [issues](https://github.com/bezumkin/nuxt-fontawesome/issues) to report problems.
 
 ## Setup
-- Add dependency using npm to your project
+- Add dependency to your project
 ```bash
 npx nuxi@latest module add nuxt-fontawesome
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please use [issues](https://github.com/bezumkin/nuxt-fontawesome/issues) to repo
 ## Setup
 - Add dependency using npm to your project
 ```bash
-npm i -D @vesp/nuxt-fontawesome
+npx nuxi@latest module add nuxt-fontawesome
 ```
 
 - Add some icon packs


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
