### PR TITLE
FontAwesome kit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,37 @@ import {faGithub} from '@fortawesome/free-brands-svg-icons'
 </script>
 ```
 
+### FontAwesome Kit
+
+You can use [kits from Fontawesome Pro](https://docs.fontawesome.com/web/setup/use-kit).
+
+1. [Retrieve your kit ID on FontAwesome](https://fontawesome.com/kits): `https://fontawesome.com/kits/**KIT_ID**/package` (10 alpha-numerics characters)
+2. In ***Settings*** tab, activate **Enable Installing Your Kit as a Package** option if not yet done
+3. Install, in your local project, your custom kit package as defined in ***Package*** tab
+4. Update `nuxt.config.ts` by adding your kit ID under `kitIdentifier` key and icons required in project under `proIcons.kit` key:
+    ```json
+    // https://nuxt.com/docs/api/configuration/nuxt-config
+    export default defineNuxtConfig({
+        compatibilityDate: '2024-11-01',
+        devtools: { enabled: true },
+        modules: [
+            '@vesp/nuxt-fontawesome'
+        ],
+        fontawesome: {
+            kitIdentifier: (KIT_ID),
+            proIcons: {
+                kit: [
+                    (ICON_NAME ex: solid-user-circle-exclamation)
+                ],
+            },
+        }
+    })
+    ```
+5. Use your imported icon in your page like this:
+    ```javascript
+    <font-awesome :icon="['fak', 'solid-user-circle-exclamation']" />
+    ```
+
 ## License
 
 [MIT License](./LICENSE.md)


### PR DESCRIPTION
# What this PR does?

This feature implements the support of FontAwesome Kits, as requested in Issue https://github.com/bezumkin/nuxt-fontawesome/issues/3

# How to test?

1. Checkout this branch
2. Enter the directory
3. Build the package (`npm run prepare`)
4. In your destination Nuxt project, change `nuxt.config.js` by changing module `@vesp/nuxt-fontawesome` to the path of nuxt-fontawesome local sources: `<rootdir>/nuxt-fontawesome/src`
5. Launch / relaunch your nuxt project (`npm run dev`)
6. Follow the documentation update in README.md under the **FontAwesome Kit** section

# Documentation

The README in this branch is updated with a new **Usage** sub-section called **FontAwesome Kit**.
