### PR TITLE
Add type annotations

### DIFF
--- a/src/runtime/components/icon.vue
+++ b/src/runtime/components/icon.vue
@@ -291,7 +291,7 @@ function nextUniqueId() {
 
 function getSVG() {
   const fill = parsedMask.value ? 'black' : 'currentColor'
-  const svg = []
+  const svg: string[] = []
 
   let path = parsedIcon.value.icon[4]
   if (!Array.isArray(path)) {

--- a/src/runtime/components/layers-text.vue
+++ b/src/runtime/components/layers-text.vue
@@ -29,7 +29,7 @@ const props = defineProps({
 
 const {familyPrefix} = config
 const classes = computed(() => {
-  const tmp = []
+  const tmp: string[] = []
   if (props.counter) {
     tmp.push(`${familyPrefix}-layers-counter`)
   } else {


### PR DESCRIPTION
vue-tsc is complaining:
`Argument of type 'string' is not assignable to parameter of type 'never'.`
even with `"exclude": ["node_modules"]` and `--skipLibCheck`

Added type annotations to `tmp` and `svg` const.